### PR TITLE
Develop

### DIFF
--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { TbCopy, TbCopyCheck } from "react-icons/tb";
+import { MdOutlineFileDownload } from "react-icons/md";
+import { MdOutlineFileDownloadDone } from "react-icons/md";
 
 interface Props {
     code: string;
@@ -7,6 +9,7 @@ interface Props {
 
 export default function CodePreview({ code }: Props) {
     const [copied, setCopied] = useState(false);
+    const [downloaded, setDownloaded] = useState(false);
 
     const handleCopy = async () => {
         try {
@@ -17,6 +20,18 @@ export default function CodePreview({ code }: Props) {
             console.error('Failed to copy!', err);
         }
     };
+
+    const handelDownload = () => {
+        const blob = new Blob([code], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'swagger-code.txt';
+        link.click();
+        URL.revokeObjectURL(url);
+        setDownloaded(true);
+        setTimeout(() => setDownloaded(false), 2000);
+    }
 
     return (
         <div className="relative">
@@ -32,6 +47,21 @@ export default function CodePreview({ code }: Props) {
                     size={25}
                 />
             )}
+            {downloaded ? (
+                <MdOutlineFileDownloadDone
+                    className="absolute top-2 right-10 text-green-400"
+                    size={27}
+                />
+            ) :
+                <button
+                    className="absolute top-2 right-10 text-slate-200 hover:text-white"
+                    onClick={handelDownload}
+                >
+                    <MdOutlineFileDownload
+                        size={27}
+                    />
+                </button>}
+
             <pre className="bg-gray-800 text-green-200 p-4 min-h-10 rounded overflow-auto whitespace-pre-wrap">
                 {code}
             </pre>

--- a/src/components/QueryParamEditor.tsx
+++ b/src/components/QueryParamEditor.tsx
@@ -39,7 +39,13 @@ export default function QueryParamEditor({ method, onUpdate }: Props) {
       {params.map((param, index) => (
         <div key={index} className="grid grid-cols-5 gap-2 items-center">
           <input className="input" placeholder="Name" value={param.name} onChange={(e) => updateParam(index, 'name', e.target.value)} />
-          <input className="input" placeholder="Type" value={param.type} onChange={(e) => updateParam(index, 'type', e.target.value)} />
+          <select className='input' value={param.type} onChange={(e) => updateParam(index, 'type', e.target.value)} id="">
+            {['string', 'number', 'boolean'].map((type) => (
+              <option key={type} value={type}>
+                {type.charAt(0) + type.slice(1)}
+              </option>
+            ))}
+          </select>
           <input className="input" placeholder="Description" value={param.description} onChange={(e) => updateParam(index, 'description', e.target.value)} />
           <label className="flex items-center">
             <input type="checkbox" className='mx-1.5' checked={param.required} onChange={(e) => updateParam(index, 'required', e.target.checked)} /> Required

--- a/src/components/RequestBodyEditor.tsx
+++ b/src/components/RequestBodyEditor.tsx
@@ -2,13 +2,7 @@ import { useEffect, useState } from 'react';
 import type { SwaggerSchemaProperty } from '../types/swagger';
 import { IoMdAddCircleOutline } from 'react-icons/io';
 import { FaDeleteLeft } from "react-icons/fa6";
-
-interface RequestField {
-  key: string;
-  type: string;
-  description: string;
-  example: string;
-}
+import type { RequestField } from '../types/swagger';
 
 interface Props {
   method: string;
@@ -64,7 +58,13 @@ export default function RequestBodyEditor({ method, onUpdate }: Props) {
       {requestFields.map((field, index) => (
         <div key={index} className="grid grid-cols-5 gap-2 items-center ">
           <input className="input" placeholder="Key" value={field.key} onChange={(e) => updateField(index, 'key', e.target.value)} />
-          <input className="input" placeholder="Type" value={field.type} onChange={(e) => updateField(index, 'type', e.target.value)} />
+          <select className="input" value={field.type} onChange={(e) => updateField(index, 'type', e.target.value)}>
+            {['string', 'number', 'boolean', 'object', 'array'].map((type) => (
+              <option key={type} value={type}>
+                {type.charAt(0) + type.slice(1)}
+              </option>
+            ))}
+          </select>
           <input className="input" placeholder="Description" value={field.description} onChange={(e) => updateField(index, 'description', e.target.value)} />
           <input className="input" placeholder="Example" value={field.example} onChange={(e) => updateField(index, 'example', e.target.value)} />
           <button

--- a/src/types/swagger.ts
+++ b/src/types/swagger.ts
@@ -29,3 +29,10 @@ export interface Response {
   code: string;
   description: string;
 }
+
+export interface RequestField {
+  key: string;
+  type: string;
+  description: string;
+  example: string;
+}


### PR DESCRIPTION
This pull request introduces new features and improvements to the `CodePreview`, `QueryParamEditor`, and `RequestBodyEditor` components, along with a small type refactor in the `swagger.ts` file. The key updates include adding a file download feature to `CodePreview`, replacing input fields with dropdowns for type selection in `QueryParamEditor` and `RequestBodyEditor`, and centralizing the `RequestField` type definition.

### New Features:
* **File Download in `CodePreview`:** Added a file download button with visual feedback for successful downloads. This includes new state management (`downloaded`) and a `handelDownload` function to generate and download a text file. [[1]](diffhunk://#diff-d6237cc27209840af6c50f09ee53c0f7e487207ecd01e704ffc6481685808fb4R3-R12) [[2]](diffhunk://#diff-d6237cc27209840af6c50f09ee53c0f7e487207ecd01e704ffc6481685808fb4R24-R35) [[3]](diffhunk://#diff-d6237cc27209840af6c50f09ee53c0f7e487207ecd01e704ffc6481685808fb4R50-R64)

### UI Improvements:
* **Dropdown for Type Selection in `QueryParamEditor`:** Replaced the `Type` input field with a dropdown to select predefined types (`string`, `number`, `boolean`). This improves user experience and reduces input errors.
* **Dropdown for Type Selection in `RequestBodyEditor`:** Updated the `Type` input field to a dropdown, allowing selection from an extended list of types (`string`, `number`, `boolean`, `object`, `array`).

### Code Refactoring:
* **Centralized `RequestField` Type:** Moved the `RequestField` interface definition from `RequestBodyEditor.tsx` to `swagger.ts` for better reusability and maintainability. [[1]](diffhunk://#diff-a7a4d6a68df776d5ec543be5c899a8dc2ff98d8b280c76a1161b195b364759a0L5-R5) [[2]](diffhunk://#diff-44bfe106940c175ce0afa121da12cb2a7999d3c82de7d5bbcd5a76721b426c59R32-R38)